### PR TITLE
Fix #5 clean duplicate env path

### DIFF
--- a/install/etc/profile.d/pathenv.sh
+++ b/install/etc/profile.d/pathenv.sh
@@ -1,1 +1,1 @@
-export PATH=/var/www/html/bin:/var/www/html/vendor/bin:/var/www/html/vendor/drush/drush:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH
+export PATH=/var/www/html/bin:/var/www/html/vendor/bin:/var/www/html/vendor/drush/drush:$PATH


### PR DESCRIPTION
PATH in docker

`PATH=/var/www/html/bin:/var/www/html/vendor/bin:/var/www/html/vendor/drush/drush:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/var/www/html/docroot/vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin`

sh:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin  is duplicate
